### PR TITLE
Switch map to Google implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,23 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>3D Terrain Generator</title>
     <link rel="stylesheet" href="style.css" />
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.13.0/mapbox-gl.js"></script>
-    <link
-      href="https://api.mapbox.com/mapbox-gl-js/v2.13.0/mapbox-gl.css"
-      rel="stylesheet"
-    />
-    <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.5.0/mapbox-gl-draw.js"></script>
-    <link
-      href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.5.0/mapbox-gl-draw.css"
-      rel="stylesheet"
-    />
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"></script>
 </head>
 
 <body>
     <h1>3D Terrain Generator</h1>
     <div id="map"></div>
     <button id="generateBtn">Generate STL</button>
-    <p id="version">Version 0.5.0002</p>
+    <p id="version">Version 0.5.0003</p>
     <script src="terrain.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- switch from Mapbox to the Google Maps JavaScript API
- let the user drag a rectangle to select an area
- call the Elevation API for a grid of heights
- convert elevations to a mesh and export as STL
- bump version number

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a3e6c7ed0832a8186f0c43ff9292a